### PR TITLE
Pyproject.toml Fix

### DIFF
--- a/ellar_cli/service/cli.py
+++ b/ellar_cli/service/cli.py
@@ -11,6 +11,7 @@ from ellar.core import Config, ModuleBase
 from ellar.utils.importer import import_from_string, module_import
 from tomlkit import dumps as tomlkit_dumps
 from tomlkit import parse as tomlkit_parse
+from tomlkit import table
 from tomlkit.items import Table
 
 from ellar_cli.constants import ELLAR_PY_PROJECT
@@ -83,13 +84,14 @@ class EllarCLIService:
 
         py_project_file_path = os.path.join(cwd, PY_PROJECT_TOML)
         if os.path.exists(py_project_file_path):
-            pyproject_table = EllarCLIService.read_py_project(py_project_file_path)
+            pyproject_table = (
+                EllarCLIService.read_py_project(py_project_file_path) or table()
+            )
             _ellar_pyproject_serializer: t.Optional[EllarPyProjectSerializer] = None
+            tools = pyproject_table.get("tool", {})
 
-            if pyproject_table and ELLAR_PY_PROJECT in pyproject_table:
-                ellar_py_projects = EllarPyProject(
-                    pyproject_table.get(ELLAR_PY_PROJECT)
-                )
+            if ELLAR_PY_PROJECT in tools:
+                ellar_py_projects = EllarPyProject(tools.get(ELLAR_PY_PROJECT))
                 if ellar_py_projects.has_project(
                     project
                 ) or ellar_py_projects.has_project(ellar_py_projects.default_project):

--- a/ellar_cli/service/pyproject.py
+++ b/ellar_cli/service/pyproject.py
@@ -22,7 +22,9 @@ class EllarPyProject:
     def get_or_create_ellar_py_project(
         cls, py_project_table: Table
     ) -> "EllarPyProject":
-        ellar_py_project_table = py_project_table.setdefault(ELLAR_PY_PROJECT, table())
+        ellar_py_project_table = py_project_table.setdefault(
+            "tool", table()
+        ).setdefault(ELLAR_PY_PROJECT, table())
         return cls(ellar_py_project_table)
 
     @property

--- a/tests/sample_app/example_project/config.py
+++ b/tests/sample_app/example_project/config.py
@@ -57,9 +57,9 @@ class BaseConfig(ConfigDefaultTypesMixin):
     ] = {}
 
     # Object Serializer custom encoders
-    SERIALIZER_CUSTOM_ENCODER: t.Dict[
-        t.Any, t.Callable[[t.Any], t.Any]
-    ] = encoders_by_type
+    SERIALIZER_CUSTOM_ENCODER: t.Dict[t.Any, t.Callable[[t.Any], t.Any]] = (
+        encoders_by_type
+    )
 
 
 class DevelopmentConfig(BaseConfig):

--- a/tests/sample_app/example_project_2/config.py
+++ b/tests/sample_app/example_project_2/config.py
@@ -57,9 +57,9 @@ class BaseConfig(ConfigDefaultTypesMixin):
     ] = {}
 
     # Object Serializer custom encoders
-    SERIALIZER_CUSTOM_ENCODER: t.Dict[
-        t.Any, t.Callable[[t.Any], t.Any]
-    ] = encoders_by_type
+    SERIALIZER_CUSTOM_ENCODER: t.Dict[t.Any, t.Callable[[t.Any], t.Any]] = (
+        encoders_by_type
+    )
 
 
 class DevelopmentConfig(BaseConfig):

--- a/tests/sample_app/example_project_3/config.py
+++ b/tests/sample_app/example_project_3/config.py
@@ -57,9 +57,9 @@ class BaseConfig(ConfigDefaultTypesMixin):
     ] = {}
 
     # Object Serializer custom encoders
-    SERIALIZER_CUSTOM_ENCODER: t.Dict[
-        t.Any, t.Callable[[t.Any], t.Any]
-    ] = encoders_by_type
+    SERIALIZER_CUSTOM_ENCODER: t.Dict[t.Any, t.Callable[[t.Any], t.Any]] = (
+        encoders_by_type
+    )
 
 
 class DevelopmentConfig(BaseConfig):

--- a/tests/sample_app/plain_project/plain_project/config.py
+++ b/tests/sample_app/plain_project/plain_project/config.py
@@ -61,9 +61,9 @@ class BaseConfig(ConfigDefaultTypesMixin):
     EXCEPTION_HANDLERS: t.List[IExceptionHandler] = []
 
     # Object Serializer custom encoders
-    SERIALIZER_CUSTOM_ENCODER: t.Dict[
-        t.Any, t.Callable[[t.Any], t.Any]
-    ] = encoders_by_type
+    SERIALIZER_CUSTOM_ENCODER: t.Dict[t.Any, t.Callable[[t.Any], t.Any]] = (
+        encoders_by_type
+    )
 
 
 class DevelopmentConfig(BaseConfig):

--- a/tests/sample_app/pyproject.toml
+++ b/tests/sample_app/pyproject.toml
@@ -1,18 +1,17 @@
-[ellar]
+[tool.ellar]
 default = "example_project"
-[ellar.projects]
-[ellar.projects.example_project]
+[tool.ellar.projects.example_project]
 project-name = "example_project"
 application = "example_project.server:application"
 config = "example_project.config:DevelopmentConfig"
 root-module = "example_project.root_module:ApplicationModule"
 
-[ellar.projects.example_project_2]
+[tool.ellar.projects.example_project_2]
 project-name = "example_project_2"
 application = "example_project_2.server:bootstrap"
 config = "example_project_2.config:DevelopmentConfig"
 root-module = "example_project_2.root_module:ApplicationModule"
-[ellar.projects.example_project_3]
+[tool.ellar.projects.example_project_3]
 project-name = "example_project_3"
 application = "example_project_3.server:bootstrap"
 config = "example_project_3.config:DevelopmentConfig"

--- a/tests/test_ellar_py_project.py
+++ b/tests/test_ellar_py_project.py
@@ -8,12 +8,13 @@ from ellar_cli.service import EllarPyProject
 def test_get_or_create_ellar_py_project(mock_py_project_table):
     assert ELLAR_PY_PROJECT not in mock_py_project_table
     EllarPyProject.get_or_create_ellar_py_project(mock_py_project_table)
-    assert ELLAR_PY_PROJECT in mock_py_project_table
+    assert ELLAR_PY_PROJECT in mock_py_project_table["tool"]
 
     new_py_project_table = table()
+    tool = new_py_project_table.setdefault("tool", table())
     ellar = table()
     ellar.update({"not_a_new_instance": True})
-    new_py_project_table.add(ELLAR_PY_PROJECT, ellar)
+    tool.add(ELLAR_PY_PROJECT, ellar)
 
     ellar_py_project = EllarPyProject.get_or_create_ellar_py_project(
         new_py_project_table
@@ -59,6 +60,6 @@ def test_get_root_node(mock_py_project_table):
     ellar_py_project = EllarPyProject.get_or_create_ellar_py_project(
         mock_py_project_table
     )
-    assert ellar_py_project.get_root_node() is mock_py_project_table.get(
+    assert ellar_py_project.get_root_node() is mock_py_project_table["tool"].get(
         ELLAR_PY_PROJECT
     )


### PR DESCRIPTION
## What's changed
- Fixed Pyproject.toml vscode errors and followed project tool convention for adding project metadata

## Breaking Changes
- Project using `Pyproject.toml` as ellar project meta data configuration should refactor the ellar config data by appending `tool.` e.g.
```
[`tool.`ellar]
default = "example_project"

[`tool.`ellar.projects.example_project]
project-name = "example_project"
application = "example_project.server:application"
config = "example_project.config:DevelopmentConfig"
root-module = "example_project.root_module:ApplicationModule"
```